### PR TITLE
Fix device address handling, repair the test suite, and report unavailability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Home Assistant ships a new python well before it becomes the default,
+        # so test the versions users actually run on.
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run tests
+        working-directory: test
+        run: python -m unittest discover -s . -p "test_*.py" -v

--- a/src/nilan_proxy/__init__.py
+++ b/src/nilan_proxy/__init__.py
@@ -1,7 +1,7 @@
 from .nilan_proxy import ( NilanProxy, NilanProxyConnectionErrorType )
 from .models import ( NilanProxyDatapointKey, NilanProxySetpointKey, NilanProxyUnits )
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __all__ = [
     "NilanProxy",
     "NilanProxyConnectionErrorType",

--- a/src/nilan_proxy/__init__.py
+++ b/src/nilan_proxy/__init__.py
@@ -1,7 +1,7 @@
 from .nilan_proxy import ( NilanProxy, NilanProxyConnectionErrorType )
 from .models import ( NilanProxyDatapointKey, NilanProxySetpointKey, NilanProxyUnits )
 
-__version__ = "1.0.3"
+__version__ = "1.0.2"
 __all__ = [
     "NilanProxy",
     "NilanProxyConnectionErrorType",

--- a/src/nilan_proxy/const.py
+++ b/src/nilan_proxy/const.py
@@ -3,6 +3,7 @@ SOCKET_MAXSIZE = 512
 DATAPOINT_UPDATEINTERVAL = 10 # Seconds since last datapoint update to trigger new update
 SETPOINT_UPDATEINTERVAL = 180 # Seconds since last setpoint update to trigger new update
 SECONDS_UNTILRECONNECT = 20 # Seconds with no response to try reconnecting
+SECONDS_UNTILUNAVAILABLE = 60 # Seconds with no response before the device is reported unavailable
 DISCOVERY_PORT = 5570
 DISCOVERY_TIMEOUT = 3 # Seconds to wait for a device to answer a discovery before giving up
 DISCOVERY_RESEND_INTERVAL = 1 # Seconds between discovery broadcasts while waiting, discovery is udp and may be dropped

--- a/src/nilan_proxy/const.py
+++ b/src/nilan_proxy/const.py
@@ -4,3 +4,6 @@ DATAPOINT_UPDATEINTERVAL = 10 # Seconds since last datapoint update to trigger n
 SETPOINT_UPDATEINTERVAL = 180 # Seconds since last setpoint update to trigger new update
 SECONDS_UNTILRECONNECT = 20 # Seconds with no response to try reconnecting
 DISCOVERY_PORT = 5570
+DISCOVERY_TIMEOUT = 3 # Seconds to wait for a device to answer a discovery before giving up
+DISCOVERY_RESEND_INTERVAL = 1 # Seconds between discovery broadcasts while waiting, discovery is udp and may be dropped
+DISCOVERY_RECONNECT_INTERVAL = 10 # Seconds between discovery broadcasts while reconnecting, to pick up a changed address

--- a/src/nilan_proxy/models/basemodel.py
+++ b/src/nilan_proxy/models/basemodel.py
@@ -383,7 +383,13 @@ class NilanProxyBaseModel:
     _valueMap: Dict[NilanProxyDatapointKey|NilanProxySetpointKey, Dict[float | int, float | int | str]] = {}
 
     def __init__(self) -> None:
-        return
+        # Bind these per instance. They are declared on the class for typing, and
+        # without this every model would read and write the same shared dicts, so
+        # one model would leak its points and configs into every other model.
+        self.datapoints = {}
+        self.setpoints = {}
+        self._configs = {}
+        self._valueMap = {}
 
     def get_model_name(self) -> str:
         return self._attr_model_name
@@ -414,8 +420,10 @@ class NilanProxyBaseModel:
 
     # def addMissingDefaultConfigs(self):
         # Update self._configs with missing items from DEFAULT_CONFIGS
+        # Copy each config, models modify their own entries afterwards and must not
+        # write through into the shared defaults.
         self._configs.update({
-            key: value for key, value in DEFAULT_CONFIGS.items()
+            key: NilanProxyPointConfig(**value) for key, value in DEFAULT_CONFIGS.items()
             if key not in self._configs and (key in self.setpoints or key in self.datapoints)
         })
     

--- a/src/nilan_proxy/models/cts602.py
+++ b/src/nilan_proxy/models/cts602.py
@@ -7,6 +7,53 @@ class NilanProxyCTS602(NilanProxyBaseModel):
         self._attr_manufacturer="Nilan"
         self._attr_model_name="CTS 602"
 
+        # Must be defined before any device_has_quirk lookup below.
+        self._quirks = {
+            "hotwaterTempSensor": [
+                9, 10, 11,  12,  18, 19,
+                20, 21, 23,  30,  32, 34,
+                38, 43, 44, 144, 244
+            ],
+            "sacrificialAnode": [
+                9, 10,  11,  12, 18, 19,
+                20, 21,  23,  30, 34, 38,
+                43, 44, 144, 244
+            ],
+            "reheat": [
+                2,   3,   4,  9, 10, 11, 12, 13, 18,
+                19,  20,  21, 23, 26, 27, 30, 31, 33,
+                34,  35,  36, 38, 39, 40, 41, 43, 44,
+                45, 144, 244
+            ],
+            "exhaustTempSensor": [ 2, 13, 27, 31 ],
+            "antiLegionella": [
+                3,  4,  9, 10,  11,  12, 18,
+                19, 20, 21, 23,  30,  32, 34,
+                38, 43, 44, 45, 144, 244
+            ],
+            "hotwaterTempSet": [
+                9, 10, 11,  12,  13, 18, 19,
+                20, 21, 23,  30,  31, 32, 34,
+                38, 43, 44, 144, 244
+            ],
+            "summerTemperatures": [
+                2,  4,  9, 10, 12, 13, 19,  21,
+                26, 30, 31, 32, 33, 34, 35,  36,
+                38, 39, 40, 41, 43, 44, 45, 144,
+                244
+            ],
+            "coolingPriority": [
+                2,  9, 10, 12, 13,  30,
+                31, 32, 38, 43, 44, 144,
+                244
+            ],
+            "coolingOffset": [
+                4,  9, 10, 12, 19,  21,  26,
+                30, 32, 33, 35, 36,  38,  39,
+                40, 41, 43, 44, 45, 144, 244
+            ]
+        }
+
         self.datapoints = {
             NilanProxyDatapointKey.BYPASS_ACTIVE: NilanProxyDatapoint(read_address=187, divider=1, signed=False),
             NilanProxyDatapointKey.CO2_LEVEL: NilanProxyDatapoint(read_address=53, divider=1, signed=False),
@@ -66,51 +113,6 @@ class NilanProxyCTS602(NilanProxyBaseModel):
         #place config modifiers here
 
         
-        self._quirks = {
-            "hotwaterTempSensor": [
-                9, 10, 11,  12,  18, 19,
-                20, 21, 23,  30,  32, 34,
-                38, 43, 44, 144, 244
-            ],
-            "sacrificialAnode": [
-                9, 10,  11,  12, 18, 19,
-                20, 21,  23,  30, 34, 38,
-                43, 44, 144, 244
-            ],
-            "reheat": [
-                2,   3,   4,  9, 10, 11, 12, 13, 18,
-                19,  20,  21, 23, 26, 27, 30, 31, 33,
-                34,  35,  36, 38, 39, 40, 41, 43, 44,
-                45, 144, 244
-            ],
-            "exhaustTempSensor": [ 2, 13, 27, 31 ],
-            "antiLegionella": [
-                3,  4,  9, 10,  11,  12, 18,
-                19, 20, 21, 23,  30,  32, 34,
-                38, 43, 44, 45, 144, 244
-            ],
-            "hotwaterTempSet": [
-                9, 10, 11,  12,  13, 18, 19,
-                20, 21, 23,  30,  31, 32, 34,
-                38, 43, 44, 144, 244
-            ],
-            "summerTemperatures": [
-                2,  4,  9, 10, 12, 13, 19,  21,
-                26, 30, 31, 32, 33, 34, 35,  36,
-                38, 39, 40, 41, 43, 44, 45, 144,
-                244
-            ],
-            "coolingPriority": [
-                2,  9, 10, 12, 13,  30,
-                31, 32, 38, 43, 44, 144,
-                244
-            ],
-            "coolingOffset": [
-                4,  9, 10, 12, 19,  21,  26,
-                30, 32, 33, 35, 36,  38,  39,
-                40, 41, 43, 44, 45, 144, 244
-            ]
-        }
         
         
     def device_has_quirk(self, quirk:str, device:int) -> bool:

--- a/src/nilan_proxy/models/optima301.py
+++ b/src/nilan_proxy/models/optima301.py
@@ -1,4 +1,4 @@
-from .basemodel import ( NilanProxyBaseModel, NilanProxyDatapointKey, NilanProxyDatapoint, NilanProxySetpointKey, NilanProxySetpoint, NilanProxyUnits )
+from .basemodel import ( NilanProxyBaseModel, NilanProxyDatapointKey, NilanProxyDatapoint, NilanProxySetpointKey, NilanProxySetpoint )
 
 class NilanProxyOptima301(NilanProxyBaseModel):
     def __init__(self, device_number:int, slave_device_number:int, slave_device_model:int):
@@ -38,4 +38,3 @@ class NilanProxyOptima301(NilanProxyBaseModel):
         self.set_default_configs()
         
         #place config modifiers here
-        self._configs[NilanProxySetpointKey.FILTER_REPLACE_INTERVAL]["unit_of_measurement"] = NilanProxyUnits.MONTHS

--- a/src/nilan_proxy/models/optima312.py
+++ b/src/nilan_proxy/models/optima312.py
@@ -1,4 +1,4 @@
-from .basemodel import ( NilanProxyBaseModel, NilanProxyDatapointKey, NilanProxyDatapoint, NilanProxySetpointKey, NilanProxySetpoint, NilanProxyUnits )
+from .basemodel import ( NilanProxyBaseModel, NilanProxyDatapointKey, NilanProxyDatapoint, NilanProxySetpointKey, NilanProxySetpoint )
 
 class NilanProxyOptima312(NilanProxyBaseModel):
     def __init__(self, device_number:int, slave_device_number:int, slave_device_model:int):
@@ -37,4 +37,3 @@ class NilanProxyOptima312(NilanProxyBaseModel):
         self.set_default_configs()
         
         #place config modifiers here
-        self._configs[NilanProxySetpointKey.FILTER_REPLACE_INTERVAL]["unit_of_measurement"] = NilanProxyUnits.MONTHS

--- a/src/nilan_proxy/nilan_proxy.py
+++ b/src/nilan_proxy/nilan_proxy.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import Callable
 from enum import Enum
+import ipaddress
 from random import randint
 import socket
 import threading
@@ -15,7 +16,7 @@ from .models import ( NilanProxyDatapointKey, NilanProxySetpointKey, NilanProxyD
 from .nilan_proxy_modeladapter import NilanProxyModelAdapter
 from .protocol import (ProxyPacketType,  ProxyPayloadIPX, ProxyPayloadCrypt, ProxyPayloadCP_ID,  ProxyPacketBuilder, NilanProxyCommandBuilder, NilanProxyCommandBuilderReadArgs)
 
-from .const import ( SOCKET_TIMEOUT, SOCKET_MAXSIZE, DATAPOINT_UPDATEINTERVAL, SETPOINT_UPDATEINTERVAL, SECONDS_UNTILRECONNECT, DISCOVERY_PORT)
+from .const import ( SOCKET_TIMEOUT, SOCKET_MAXSIZE, DATAPOINT_UPDATEINTERVAL, SETPOINT_UPDATEINTERVAL, SECONDS_UNTILRECONNECT, DISCOVERY_PORT, DISCOVERY_TIMEOUT, DISCOVERY_RESEND_INTERVAL, DISCOVERY_RECONNECT_INTERVAL)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ class NilanProxy():
     _last_response:float = 0
     _last_dataupdate:float = 0
     _last_setpointupdate:float = 0
+    _last_discovery:float = 0
 
     _socket = None
     _listen_thread = None
@@ -74,14 +76,48 @@ class NilanProxy():
     def get_device_manufacturer(self): return None if self._model_adapter is None else self._model_adapter.get_manufacturer()
     def get_loaded_model_name(self): return None if self._model_adapter is None else self._model_adapter.get_model_name()
     
+    @staticmethod
+    def sanitize_device_ip(device_ip:str|None) -> str|None:
+        """Return device_ip as a valid IPv4 string, or None when it is not usable.
+
+        Only literal IPv4 addresses are accepted. Hostnames are rejected on purpose:
+        the address is only a cache that discovery refreshes, and anything else would
+        end up in a name lookup inside socket.sendto instead of failing here.
+        """
+        if device_ip is None: return None
+        value = str(device_ip).strip()
+        if len(value) == 0: return None
+        try:
+            return str(ipaddress.IPv4Address(value))
+        except ValueError:
+            _LOGGER.warning(f"Ignoring invalid device ip: '{device_ip}'. Falling back to discovery.")
+            return None
+
+    @staticmethod
+    def sanitize_device_port(device_port:int|None) -> int|None:
+        """Return device_port as a valid port number, or None when it is not usable."""
+        if device_port is None: return None
+        try:
+            value = int(device_port)
+        except (TypeError, ValueError):
+            _LOGGER.warning(f"Ignoring invalid device port: '{device_port}'. Falling back to discovery.")
+            return None
+        if value <= 0 or value > 65535:
+            _LOGGER.warning(f"Ignoring invalid device port: '{device_port}'. Falling back to discovery.")
+            return None
+        return value
+
     def set_device(self, device_id:str, device_ip:str|None=None, device_port:int|None=None) -> None:
+        """Set the device to talk to. Leave device_ip/device_port unset to let discovery find the address."""
         self._device_id = device_id
-        if device_ip is None or device_port is None:
+        ip = self.sanitize_device_ip(device_ip)
+        port = self.sanitize_device_port(device_port)
+        if ip is None or port is None:
             self.retrieve_device_ip()
         else:
-            self._device_ip = device_ip
-            self._device_port = device_port
-            self._discovered_devices[self._device_id] = (device_ip, device_port)
+            self._device_ip = ip
+            self._device_port = port
+            self._discovered_devices[self._device_id] = (ip, port)
         
     def start_listening(self) -> bool:
         if self._listen_thread_open: return False
@@ -118,9 +154,9 @@ class NilanProxy():
         await asyncio.sleep(0.5) # Allow for all devices to reply
         return self._discovered_devices
 
-    def retrieve_device_ip(self) -> None:
+    def retrieve_device_ip(self, force_discovery:bool=False) -> None:
         # Check if we already know the IP from earlier
-        if self._device_id in self._discovered_devices:
+        if not force_discovery and self._device_id in self._discovered_devices:
             self._device_ip = self._discovered_devices[self._device_id][0]
             self._device_port = self._discovered_devices[self._device_id][1]
         else:
@@ -130,6 +166,9 @@ class NilanProxy():
         if self._socket == None:
             return False
         if self._listen_thread_open == False:
+            return False
+        if self._device_ip is None:
+            _LOGGER.debug("No device address known yet, cannot connect.")
             return False
         self._connection_error = None
         ipx_payload = ProxyPayloadIPX()
@@ -147,13 +186,22 @@ class NilanProxy():
             await asyncio.sleep(0.2)
 
     async def wait_for_discovery(self) -> bool:
-        """Wait for discovery of ip to be done"""
-        discovery_timeout = time.time() + 3
+        """Wait for discovery of ip to be done.
+
+        Discovery is a udp broadcast and may be dropped without notice, so resend it
+        while waiting. A single lost packet should not fail the whole discovery.
+        """
+        discovery_timeout = time.time() + DISCOVERY_TIMEOUT
+        next_resend = time.time() + DISCOVERY_RESEND_INTERVAL
         while True:
             if self._device_id in self._discovered_devices and self._device_ip is not None:
                 return True
-            if time.time() > discovery_timeout:
+            now = time.time()
+            if now > discovery_timeout:
                 return False
+            if now >= next_resend:
+                next_resend = now + DISCOVERY_RESEND_INTERVAL
+                self.send_discovery(self._device_id)
             await asyncio.sleep(0.2)
 
     async def wait_for_data(self) -> bool:
@@ -253,11 +301,12 @@ class NilanProxy():
             device_id = discovery_response[0: device_id_length].decode("ascii")
             if "remote.lscontrol.dk" in device_id:
                 # This is a valid reponse from a ProxyConnect device!
-                # Add the device Id and IP to our list if not seen before.
-                if device_id not in self._discovered_devices:
-                    self._discovered_devices[device_id] = address
+                # Always store the address, the device may have been given a new one
+                # since we last saw it. The device id is what identifies it, not the address.
+                self._discovered_devices[device_id] = address
             if device_id == self._device_id:
                 self._device_ip = address[0]
+                self._device_port = address[1]
             return
         if message[0:4] != self._client_id: # Not a packet intented for us
             return
@@ -347,6 +396,11 @@ class NilanProxy():
                     if time.time() - self._last_setpointupdate > SETPOINT_UPDATEINTERVAL:                    
                         self._send_setpoint_state_request(200)
                     if time.time() - self._last_response > SECONDS_UNTILRECONNECT:
+                        # The address is only a cache. The device may have been given a new
+                        # one while we were unable to reach it, so ask discovery again.
+                        if time.time() - self._last_discovery > DISCOVERY_RECONNECT_INTERVAL:
+                            self._last_discovery = time.time()
+                            self.retrieve_device_ip(force_discovery=True)
                         self.connect_to_device()
             except Exception as e:
                 _LOGGER.error(f"Error in receive thread: {e}")

--- a/src/nilan_proxy/nilan_proxy.py
+++ b/src/nilan_proxy/nilan_proxy.py
@@ -16,7 +16,7 @@ from .models import ( NilanProxyDatapointKey, NilanProxySetpointKey, NilanProxyD
 from .nilan_proxy_modeladapter import NilanProxyModelAdapter
 from .protocol import (ProxyPacketType,  ProxyPayloadIPX, ProxyPayloadCrypt, ProxyPayloadCP_ID,  ProxyPacketBuilder, NilanProxyCommandBuilder, NilanProxyCommandBuilderReadArgs)
 
-from .const import ( SOCKET_TIMEOUT, SOCKET_MAXSIZE, DATAPOINT_UPDATEINTERVAL, SETPOINT_UPDATEINTERVAL, SECONDS_UNTILRECONNECT, DISCOVERY_PORT, DISCOVERY_TIMEOUT, DISCOVERY_RESEND_INTERVAL, DISCOVERY_RECONNECT_INTERVAL)
+from .const import ( SOCKET_TIMEOUT, SOCKET_MAXSIZE, DATAPOINT_UPDATEINTERVAL, SETPOINT_UPDATEINTERVAL, SECONDS_UNTILRECONNECT, SECONDS_UNTILUNAVAILABLE, DISCOVERY_PORT, DISCOVERY_TIMEOUT, DISCOVERY_RESEND_INTERVAL, DISCOVERY_RECONNECT_INTERVAL)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,11 +41,18 @@ class NilanProxy():
     _model_adapter:NilanProxyModelAdapter|None = None
 
     _is_connected:bool = False
+    """A session has been established and a model was loaded. Gates the polling and
+    reconnect logic, and is not the same thing as the device being reachable."""
+    _is_available:bool = False
+    """The device answered recently. This is what entities should reflect."""
     _connection_error:NilanProxyConnectionErrorType|None = None
     _last_response:float = 0
     _last_dataupdate:float = 0
     _last_setpointupdate:float = 0
     _last_discovery:float = 0
+
+    _connection_state_handlers:List[Callable[[bool], None]] = []
+    """Callable[is_available]. Bound per instance in __init__."""
 
     _socket = None
     _listen_thread = None
@@ -55,6 +62,8 @@ class NilanProxy():
     
     def __init__(self, authorized_email:str = "") -> None:
         self._authorized_email = authorized_email
+        # Bind before the listen thread starts, it notifies through this list.
+        self._connection_state_handlers = []
         self.start_listening()
         return    
     
@@ -63,6 +72,10 @@ class NilanProxy():
     """set the email the system was configured with through the official application/app"""
     
     def is_connected(self): return self._is_connected
+    def is_available(self) -> bool:
+        """True while the device is answering. Goes false after SECONDS_UNTILUNAVAILABLE
+        without a response, so consumers can stop presenting stale readings as current."""
+        return self._is_available
     def get_connection_error(self): return self._connection_error
     
     def get_device_id(self): return self._device_id
@@ -247,6 +260,36 @@ class NilanProxy():
         if self._model_adapter is not None:
             self._model_adapter.notify_all_update_handlers()
     
+    def register_connection_state_handler(self, handler: Callable[[bool], None]) -> None:
+        """Called with the new availability whenever it changes."""
+        if handler not in self._connection_state_handlers:
+            self._connection_state_handlers.append(handler)
+
+    def deregister_connection_state_handler(self, handler: Callable[[bool], None]) -> None:
+        if handler in self._connection_state_handlers:
+            self._connection_state_handlers.remove(handler)
+
+    def _set_available(self, available:bool) -> None:
+        """Notify listeners, but only when the state actually flips."""
+        if available == self._is_available: return
+        self._is_available = available
+        _LOGGER.debug(f"Device availability changed to {available}")
+        for handler in list(self._connection_state_handlers):
+            try:
+                handler(available)
+            except Exception as e:
+                # A listener must never be able to kill the receive thread.
+                _LOGGER.error(f"Error in connection state handler: {e}")
+
+    def _update_availability(self) -> None:
+        """Availability is derived from the last response only.
+
+        Deliberately kept separate from _is_connected: that flag gates the polling and
+        reconnect logic in the receive thread, so clearing it on a dropped connection
+        would stop the reconnect attempts and the device would never come back.
+        """
+        self._set_available(time.time() - self._last_response <= SECONDS_UNTILUNAVAILABLE)
+
     def register_update_handler(self, key: NilanProxyDatapointKey|NilanProxySetpointKey, updateMethod: Callable[[float|int, float|int], None]) -> None:
         if self._model_adapter is not None:
             self._model_adapter.register_update_handler(key, updateMethod)
@@ -389,6 +432,7 @@ class NilanProxy():
         while self._listen_thread_open:
             try :
                 self._handle_receive()
+                self._update_availability()
                 if self._is_connected:
                     if time.time() - self._last_dataupdate > DATAPOINT_UPDATEINTERVAL:
                         _LOGGER.debug("Sending data request..")

--- a/src/nilan_proxy/nilan_proxy_modeladapter.py
+++ b/src/nilan_proxy/nilan_proxy_modeladapter.py
@@ -19,7 +19,11 @@ class NilanProxyModelAdapter:
         if model_to_load == None:
             raise Exception("Invalid model")
         self._loaded_model = model_to_load(device_number, slave_device_number, slave_device_model)
-            
+
+        # Bind per instance. Declared on the class for typing only, sharing them would
+        # mix values and handlers between two devices set up in the same process.
+        self._values = {}
+        self._update_handlers = {}
         self._current_datapoint_list = {100: self._loaded_model.get_datapoints_for_read()}
         self._current_setpoint_list = {200: self._loaded_model.get_setpoints_for_read()}
 

--- a/test/common.py
+++ b/test/common.py
@@ -3,3 +3,19 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 
 from nilan_proxy import *
 from nilan_proxy.models import *
+
+
+def make_offline_proxy():
+    """A proxy with its listen thread stopped and socket closed.
+
+    Tests drive the state machine directly instead of talking to a device, so nothing
+    must be listening or broadcasting while they do.
+    """
+    proxy = NilanProxy()
+    proxy.stop_listening()
+    if proxy._listen_thread is not None:
+        proxy._listen_thread.join(timeout=5)
+    proxy.close_socket()
+    proxy._discovered_devices = {}
+    proxy._device_ip = None
+    return proxy

--- a/test/modelTester.py
+++ b/test/modelTester.py
@@ -1,57 +1,120 @@
-from common import NilanProxyBaseModel, NilanProxySetpointKey, NilanProxyDatapointKey
-import sys
 import unittest
-import logging
-logging.basicConfig( stream=sys.stderr )
-logging.getLogger( "SomeTest.testSomething" ).setLevel( logging.DEBUG )
+from common import (
+    NilanProxyBaseModel,
+    NilanProxyCTS400,
+    NilanProxyOptima270,
+)
+
+
 class modelTester(unittest.TestCase):
+    """Checks every model must pass. Subclasses replace loadedModel in setUp."""
 
     def setUp(self):
         self.loadedModel = NilanProxyBaseModel()
         self.expectedName = "Basemodel"
         self.expectedManufacturer = ""
 
+    # ------------------------------------------------------------------ identity
+
     def test_correct_name(self):
         self.assertEqual(self.expectedName, self.loadedModel.get_model_name())
 
     def test_correct_manufacturer(self):
-        self.assertEqual(self.expectedManufacturer, self.loadedModel.get_manufacturer())    
-    
-    def test_valid_setpoint_keys(self):
-        for key in self.loadedModel.setpoints:            
-            currentSetpoint = self.loadedModel.setpoints[key]    
-            self.assertIsNotNone(currentSetpoint["read_obj"])
-            self.assertIsNotNone(currentSetpoint['read_address'])
-            self.assertIsNotNone(currentSetpoint["write_obj"])
-            self.assertIsNotNone(currentSetpoint['write_address'])
-            self.assertIsNotNone(currentSetpoint['divider'])
-            self.assertIsNotNone(currentSetpoint['min'])
-            self.assertIsNotNone(currentSetpoint['max'])
+        self.assertEqual(self.expectedManufacturer, self.loadedModel.get_manufacturer())
 
-            self.assertNotEqual(currentSetpoint['divider'], 0)
-        
-    def test_valid_datapoint_keys(self):
-        for key in self.loadedModel.datapoints:
-            currentDatapoint = self.loadedModel.datapoints[key]
-            self.assertIsNotNone(currentDatapoint['obj'])
-            self.assertIsNotNone(currentDatapoint['address'])
-            self.assertIsNotNone(currentDatapoint['divider'])
-            self.assertIsNotNone(currentDatapoint['offset'])
+    # ------------------------------------------------------- point definitions
 
-            self.assertNotEqual(currentDatapoint['divider'], 0)
-        
+    def test_datapoints_have_required_fields(self):
+        for key, point in self.loadedModel.datapoints.items():
+            with self.subTest(datapoint=key.value):
+                self.assertIsInstance(point.get('read_address'), int)
+                self.assertGreaterEqual(point['read_address'], 0)
+                self.assertIsInstance(point.get('signed'), bool)
+                self.assertNotEqual(point.get('divider', 1), 0, "a divider of 0 would raise on every read")
+
+    def test_setpoints_have_required_fields(self):
+        for key, point in self.loadedModel.setpoints.items():
+            with self.subTest(setpoint=key.value):
+                self.assertIsInstance(point.get('read_address'), int)
+                self.assertGreaterEqual(point['read_address'], 0)
+                self.assertIsInstance(point.get('write_address'), int)
+                self.assertGreaterEqual(point['write_address'], 0)
+                self.assertIsInstance(point.get('signed'), bool)
+                self.assertNotEqual(point.get('divider', 1), 0, "a divider of 0 would raise on every read")
+                self.assertIsInstance(point.get('min'), int)
+                self.assertIsInstance(point.get('max'), int)
+                self.assertLessEqual(point['min'], point['max'])
+                if 'step' in point:
+                    self.assertGreater(point['step'], 0)
+
+    def test_datapoint_addresses_are_unique(self):
+        """Two datapoints reading the same register is almost always a copy/paste slip."""
+        seen = {}
+        for key, point in self.loadedModel.datapoints.items():
+            address = (point.get('read_obj', 0), point['read_address'])
+            self.assertNotIn(address, seen, f"{key.value} reads the same register as {seen.get(address)}")
+            seen[address] = key.value
+
+    # ------------------------------------------------------------- read lists
+
     def test_datapoint_request_is_list(self):
         self.assertIsInstance(self.loadedModel.get_datapoints_for_read(), list)
 
     def test_valid_datapoint_request(self):
-        datapointRequest = self.loadedModel.get_datapoints_for_read()
-        for key in datapointRequest:
+        for key in self.loadedModel.get_datapoints_for_read():
             self.assertIn(key, self.loadedModel.datapoints)
 
     def test_setpoint_request_is_list(self):
         self.assertIsInstance(self.loadedModel.get_setpoints_for_read(), list)
 
     def test_valid_setpoint_request(self):
-        setpointRequest = self.loadedModel.get_setpoints_for_read()
-        for key in setpointRequest:
+        for key in self.loadedModel.get_setpoints_for_read():
             self.assertIn(key, self.loadedModel.setpoints)
+
+    # --------------------------------------------------------------- configs
+
+    def test_every_point_has_a_config(self):
+        """A point without a config is never requested and reports no unit."""
+        for key in self.loadedModel.datapoints:
+            with self.subTest(datapoint=key.value):
+                self.assertIn(key, self.loadedModel._configs)
+        for key in self.loadedModel.setpoints:
+            with self.subTest(setpoint=key.value):
+                self.assertIn(key, self.loadedModel._configs)
+
+    def test_no_config_for_points_the_model_lacks(self):
+        """Configuring a point the model does not have means it came from somewhere else."""
+        for key in self.loadedModel._configs:
+            with self.subTest(point=key.value):
+                self.assertTrue(
+                    key in self.loadedModel.datapoints or key in self.loadedModel.setpoints,
+                    f"{key.value} is configured but is not a point on this model",
+                )
+
+    def test_readable_points_are_requested(self):
+        readable_datapoints = self.loadedModel.get_datapoints_for_read()
+        readable_setpoints = self.loadedModel.get_setpoints_for_read()
+        for key, config in self.loadedModel._configs.items():
+            if not config.get('read', False):
+                continue
+            with self.subTest(point=key.value):
+                if key in self.loadedModel.datapoints:
+                    self.assertIn(key, readable_datapoints)
+                if key in self.loadedModel.setpoints:
+                    self.assertIn(key, readable_setpoints)
+
+    # -------------------------------------------------------------- isolation
+
+    def test_loading_another_model_does_not_change_this_one(self):
+        """Models must not share state. One model used to overwrite another's configs."""
+        keys = list(self.loadedModel.datapoints) + list(self.loadedModel.setpoints)
+        before_points = (dict(self.loadedModel.datapoints), dict(self.loadedModel.setpoints))
+        before_units = {key: self.loadedModel.get_unit_of_measure(key) for key in keys}
+        before_read = (self.loadedModel.get_datapoints_for_read(), self.loadedModel.get_setpoints_for_read())
+
+        NilanProxyOptima270(0, 0, 0)
+        NilanProxyCTS400(0, 0, 0)
+
+        self.assertEqual(before_points, (dict(self.loadedModel.datapoints), dict(self.loadedModel.setpoints)))
+        self.assertEqual(before_units, {key: self.loadedModel.get_unit_of_measure(key) for key in keys})
+        self.assertEqual(before_read, (self.loadedModel.get_datapoints_for_read(), self.loadedModel.get_setpoints_for_read()))

--- a/test/test_availability.py
+++ b/test/test_availability.py
@@ -1,0 +1,103 @@
+import time
+import unittest
+from common import make_offline_proxy
+from nilan_proxy.const import SECONDS_UNTILUNAVAILABLE
+
+
+class AvailabilityTest(unittest.TestCase):
+    """Availability must reflect whether the device actually answers.
+
+    Showing the last known reading as if it were current is worse than showing
+    nothing, so this drives the state machine directly and checks both the flag
+    and the notification that pushes it out to consumers.
+    """
+
+    def setUp(self):
+        self.proxy = make_offline_proxy()
+        self.seen = []
+        self.proxy.register_connection_state_handler(self.seen.append)
+
+    def set_silence(self, seconds):
+        """Pretend the last response arrived this many seconds ago."""
+        self.proxy._last_response = time.time() - seconds
+
+    def test_starts_unavailable(self):
+        self.assertFalse(self.proxy.is_available())
+
+    def test_becomes_available_after_a_response(self):
+        self.set_silence(0)
+        self.proxy._update_availability()
+        self.assertTrue(self.proxy.is_available())
+        self.assertEqual(self.seen, [True])
+
+    def test_stays_available_just_below_the_threshold(self):
+        self.set_silence(SECONDS_UNTILUNAVAILABLE - 1)
+        self.proxy._update_availability()
+        self.assertTrue(self.proxy.is_available())
+
+    def test_becomes_unavailable_after_the_threshold(self):
+        self.set_silence(0)
+        self.proxy._update_availability()
+        self.set_silence(SECONDS_UNTILUNAVAILABLE + 1)
+        self.proxy._update_availability()
+        self.assertFalse(self.proxy.is_available())
+        self.assertEqual(self.seen, [True, False])
+
+    def test_recovers_when_the_device_answers_again(self):
+        for silence in (0, SECONDS_UNTILUNAVAILABLE + 1, 0):
+            self.set_silence(silence)
+            self.proxy._update_availability()
+        self.assertTrue(self.proxy.is_available())
+        self.assertEqual(self.seen, [True, False, True])
+
+    def test_handler_only_fires_on_change(self):
+        self.set_silence(0)
+        for _ in range(5):
+            self.proxy._update_availability()
+        self.assertEqual(self.seen, [True])
+
+    def test_deregistered_handler_stops_firing(self):
+        self.proxy.deregister_connection_state_handler(self.seen.append)
+        self.set_silence(0)
+        self.proxy._update_availability()
+        self.assertTrue(self.proxy.is_available())
+        self.assertEqual(self.seen, [])
+
+    def test_registering_twice_notifies_once(self):
+        self.proxy.register_connection_state_handler(self.seen.append)
+        self.set_silence(0)
+        self.proxy._update_availability()
+        self.assertEqual(self.seen, [True])
+
+    def test_a_raising_handler_does_not_stop_the_others(self):
+        """The receive thread notifies through these. One bad listener must not
+        take the connection down with it."""
+        def boom(available):
+            raise RuntimeError("handler blew up")
+        self.proxy.register_connection_state_handler(boom)
+        self.set_silence(0)
+        self.proxy._update_availability()
+        self.assertEqual(self.seen, [True])
+        self.assertTrue(self.proxy.is_available())
+
+    def test_availability_does_not_gate_the_reconnect_logic(self):
+        """_is_connected drives polling and reconnecting in the receive thread.
+        Going unavailable must leave it alone, or the device never comes back."""
+        self.proxy._is_connected = True
+        self.set_silence(SECONDS_UNTILUNAVAILABLE + 1)
+        self.proxy._update_availability()
+        self.assertFalse(self.proxy.is_available())
+        self.assertTrue(self.proxy.is_connected())
+
+    def test_handlers_are_not_shared_between_proxies(self):
+        other = make_offline_proxy()
+        other_seen = []
+        other.register_connection_state_handler(other_seen.append)
+        self.set_silence(0)
+        self.proxy._update_availability()
+        self.assertEqual(self.seen, [True])
+        self.assertEqual(other_seen, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_cts400.py
+++ b/test/test_cts400.py
@@ -2,11 +2,13 @@ import unittest
 from common import NilanProxyCTS400
 from modelTester import modelTester
 
-class CTS400Test(modelTester):    
+
+class CTS400Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyCTS400()
+        self.loadedModel = NilanProxyCTS400(0, 0, 0)
         self.expectedName = "CTS 400"
         self.expectedManufacturer = "Nilan"
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_cts602.py
+++ b/test/test_cts602.py
@@ -1,27 +1,64 @@
 import unittest
-from common import NilanProxyCTS602, NilanProxyDatapointKey
+from common import NilanProxyCTS602, NilanProxyCTS602Light, NilanProxyDatapointKey, NilanProxySetpointKey
 from modelTester import modelTester
 
-class CTS602WithNoQuirksTest(modelTester):    
+# slave device models, picked from the quirk tables in cts602.py
+NO_QUIRKS = 0
+HOTWATER = 12
+
+
+class CTS602WithNoQuirksTest(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyCTS602()
-        self.loadedModel.add_device_quirks(0,0,0) # Should not load any quirks.
+        self.loadedModel = NilanProxyCTS602(0, 0, NO_QUIRKS)
         self.expectedName = "CTS 602"
         self.expectedManufacturer = "Nilan"
 
     def test_quirks_not_loaded(self):
         self.assertNotIn(NilanProxyDatapointKey.TEMP_HOTWATER_TOP, self.loadedModel.datapoints)
 
-class CTS602WithQuirksTest(modelTester):    
+
+class CTS602WithQuirksTest(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyCTS602()
-        self.loadedModel.add_device_quirks(0,0,12)
+        self.loadedModel = NilanProxyCTS602(0, 0, HOTWATER)
         self.expectedName = "CTS 602"
         self.expectedManufacturer = "Nilan"
 
     def test_hotwater_temp_quirk_loaded(self):
         self.assertIn(NilanProxyDatapointKey.TEMP_HOTWATER_TOP, self.loadedModel.datapoints)
-    
+        self.assertIn(NilanProxyDatapointKey.TEMP_HOTWATER_BOTTOM, self.loadedModel.datapoints)
+
+    def test_quirk_points_are_configured_and_read(self):
+        """A quirk point that never gets a config would silently never be read."""
+        for key in (NilanProxyDatapointKey.TEMP_HOTWATER_TOP, NilanProxyDatapointKey.TEMP_HOTWATER_BOTTOM):
+            with self.subTest(datapoint=key.value):
+                self.assertIn(key, self.loadedModel._configs)
+                self.assertIn(key, self.loadedModel.get_datapoints_for_read())
+
+
+class CTS602QuirkSelectionTest(unittest.TestCase):
+    """Quirks are looked up during __init__, so they must be defined before use."""
+
+    def test_all_quirk_devices_load(self):
+        quirk_devices = sorted({d for devices in NilanProxyCTS602(0, 0, NO_QUIRKS)._quirks.values() for d in devices})
+        self.assertTrue(quirk_devices)
+        for device in quirk_devices:
+            with self.subTest(slave_device_model=device):
+                model = NilanProxyCTS602(0, 0, device)
+                self.assertEqual(model.get_model_name(), "CTS 602")
+
+    def test_quirks_only_add_points(self):
+        base = NilanProxyCTS602(0, 0, NO_QUIRKS)
+        quirked = NilanProxyCTS602(0, 0, HOTWATER)
+        self.assertLessEqual(set(base.datapoints), set(quirked.datapoints))
+        self.assertLessEqual(set(base.setpoints), set(quirked.setpoints))
+
+
+class CTS602LightTest(modelTester):
+    def setUp(self):
+        self.loadedModel = NilanProxyCTS602Light(0, 0, 2)
+        self.expectedName = "CTS 602 light"
+        self.expectedManufacturer = "Nilan"
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_device_address.py
+++ b/test/test_device_address.py
@@ -1,0 +1,67 @@
+import unittest
+from common import NilanProxy
+
+
+class DeviceAddressTest(unittest.TestCase):
+    """Covers the address handling that made setup fail with socket.gaierror.
+
+    An unset ip in a config entry used to reach set_device as the literal string
+    "None", which was stored as a valid address and later handed to socket.sendto
+    as a hostname to resolve.
+    """
+
+    def test_sanitize_device_ip_accepts_ipv4(self):
+        self.assertEqual(NilanProxy.sanitize_device_ip("192.168.1.50"), "192.168.1.50")
+        self.assertEqual(NilanProxy.sanitize_device_ip("  192.168.1.50  "), "192.168.1.50")
+
+    def test_sanitize_device_ip_rejects_unusable(self):
+        for value in (None, "", "   ", "None", "nilan.local", "999.1.1.1", "192.168.1"):
+            with self.subTest(value=value):
+                self.assertIsNone(NilanProxy.sanitize_device_ip(value))
+
+    def test_sanitize_device_port_accepts_valid(self):
+        self.assertEqual(NilanProxy.sanitize_device_port(5570), 5570)
+        self.assertEqual(NilanProxy.sanitize_device_port("5570"), 5570)
+
+    def test_sanitize_device_port_rejects_unusable(self):
+        for value in (None, 0, -1, 65536, "", "abc"):
+            with self.subTest(value=value):
+                self.assertIsNone(NilanProxy.sanitize_device_port(value))
+
+    def _make_proxy(self):
+        proxy = NilanProxy()
+        proxy.stop_listening()
+        if proxy._listen_thread is not None:
+            proxy._listen_thread.join(timeout=5)
+        proxy.close_socket()
+        proxy._discovered_devices = {}
+        proxy._device_ip = None
+        return proxy
+
+    def test_set_device_ignores_unset_address(self):
+        """An unset address must leave the proxy waiting for discovery, not poisoned."""
+        proxy = self._make_proxy()
+        proxy.set_device("abcd.remote.lscontrol.dk", "None", 0)
+        self.assertIsNone(proxy.get_device_ip())
+        self.assertEqual(proxy.get_discovered_devices(), {})
+
+    def test_set_device_keeps_manual_address(self):
+        proxy = self._make_proxy()
+        proxy.set_device("abcd.remote.lscontrol.dk", "192.168.1.50", 5570)
+        self.assertEqual(proxy.get_device_ip(), "192.168.1.50")
+        self.assertEqual(proxy.get_device_port(), 5570)
+        self.assertEqual(proxy.get_discovered_devices(), {"abcd.remote.lscontrol.dk": ("192.168.1.50", 5570)})
+
+    def test_connect_without_address_returns_false(self):
+        """Must fail cleanly instead of raising socket.gaierror out of setup."""
+        proxy = self._make_proxy()
+        proxy.set_device("abcd.remote.lscontrol.dk", None, None)
+        # Isolate the address check by satisfying the guards in front of it. Without
+        # the check this would reach sendto on this object and raise instead.
+        proxy._socket = object()
+        proxy._listen_thread_open = True
+        self.assertFalse(proxy.connect_to_device())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_device_address.py
+++ b/test/test_device_address.py
@@ -1,5 +1,5 @@
 import unittest
-from common import NilanProxy
+from common import NilanProxy, make_offline_proxy
 
 
 class DeviceAddressTest(unittest.TestCase):
@@ -28,25 +28,16 @@ class DeviceAddressTest(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertIsNone(NilanProxy.sanitize_device_port(value))
 
-    def _make_proxy(self):
-        proxy = NilanProxy()
-        proxy.stop_listening()
-        if proxy._listen_thread is not None:
-            proxy._listen_thread.join(timeout=5)
-        proxy.close_socket()
-        proxy._discovered_devices = {}
-        proxy._device_ip = None
-        return proxy
 
     def test_set_device_ignores_unset_address(self):
         """An unset address must leave the proxy waiting for discovery, not poisoned."""
-        proxy = self._make_proxy()
+        proxy = make_offline_proxy()
         proxy.set_device("abcd.remote.lscontrol.dk", "None", 0)
         self.assertIsNone(proxy.get_device_ip())
         self.assertEqual(proxy.get_discovered_devices(), {})
 
     def test_set_device_keeps_manual_address(self):
-        proxy = self._make_proxy()
+        proxy = make_offline_proxy()
         proxy.set_device("abcd.remote.lscontrol.dk", "192.168.1.50", 5570)
         self.assertEqual(proxy.get_device_ip(), "192.168.1.50")
         self.assertEqual(proxy.get_device_port(), 5570)
@@ -54,7 +45,7 @@ class DeviceAddressTest(unittest.TestCase):
 
     def test_connect_without_address_returns_false(self):
         """Must fail cleanly instead of raising socket.gaierror out of setup."""
-        proxy = self._make_proxy()
+        proxy = make_offline_proxy()
         proxy.set_device("abcd.remote.lscontrol.dk", None, None)
         # Isolate the address check by satisfying the guards in front of it. Without
         # the check this would reach sendto on this object and raise instead.

--- a/test/test_genvex.py
+++ b/test/test_genvex.py
@@ -1,48 +1,59 @@
 import unittest
-from common import NilanProxyOptima250, NilanProxyOptima251, NilanProxyOptima260, NilanProxyOptima270, NilanProxyOptima301, NilanProxyOptima312, NilanProxyOptima314
+from common import (
+    NilanProxyOptima250, NilanProxyOptima251, NilanProxyOptima260, NilanProxyOptima270,
+    NilanProxyOptima301, NilanProxyOptima312, NilanProxyOptima314,
+)
 from modelTester import modelTester
 
-class Optima250Test(modelTester):    
+
+class Optima250Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyOptima250()
+        self.loadedModel = NilanProxyOptima250(0, 0, 0)
         self.expectedName = "Optima 250"
         self.expectedManufacturer = "Genvex"
 
-class Optima251Test(modelTester):    
+
+class Optima251Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyOptima251()
+        self.loadedModel = NilanProxyOptima251(0, 0, 0)
         self.expectedName = "Optima 251"
         self.expectedManufacturer = "Genvex"
 
+
 class Optima260Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyOptima260()
+        self.loadedModel = NilanProxyOptima260(0, 0, 0)
         self.expectedName = "Optima 260"
         self.expectedManufacturer = "Genvex"
 
+
 class Optima270Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyOptima270()
+        self.loadedModel = NilanProxyOptima270(0, 0, 0)
         self.expectedName = "Optima 270"
         self.expectedManufacturer = "Genvex"
 
+
 class Optima301Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyOptima301()
+        self.loadedModel = NilanProxyOptima301(0, 0, 0)
         self.expectedName = "Optima 301"
         self.expectedManufacturer = "Genvex"
 
+
 class Optima312Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyOptima312()
+        self.loadedModel = NilanProxyOptima312(0, 0, 0)
         self.expectedName = "Optima 312"
         self.expectedManufacturer = "Genvex"
 
+
 class Optima314Test(modelTester):
     def setUp(self):
-        self.loadedModel = NilanProxyOptima314()
+        self.loadedModel = NilanProxyOptima314(0, 0, 0)
         self.expectedName = "Optima 314"
         self.expectedManufacturer = "Genvex"
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_modeladapter.py
+++ b/test/test_modeladapter.py
@@ -1,0 +1,172 @@
+import unittest
+from common import NilanProxyDatapointKey, NilanProxySetpointKey
+from nilan_proxy.nilan_proxy_modeladapter import NilanProxyModelAdapter
+
+# model, device_number, slave_device_number, slave_device_model -> expected model name
+SUPPORTED_DEVICES = [
+    ((2010, 79265, 0, 0), "Optima 270"),
+    ((2020, 79280, 0, 0), "Optima 314"),
+    ((1040, 0, 70810, 26), "Optima 260"),
+    ((1040, 0, 79250, 9), "Optima 312"),
+    ((1040, 0, 79250, 8), "Optima 251"),
+    ((1040, 0, 79250, 5), "Optima 301"),
+    ((1040, 0, 79250, 1), "Optima 250"),
+    ((1140, 0, 72270, 1), "CTS 400"),
+    ((1141, 0, 72270, 1), "CTS 400"),
+    ((1140, 0, 2763306, 2), "CTS 602 light"),
+    ((1140, 0, 2763306, 12), "CTS 602"),
+    ((1141, 0, 2763306, 0), "CTS 602"),
+]
+
+CTS400 = (1140, 0, 72270, 1)
+
+
+def build_datapoint_payload(values):
+    """Payload as the device sends it: 2 byte count, then one 16 bit register each."""
+    return len(values).to_bytes(2, 'big') + b''.join(v.to_bytes(2, 'big') for v in values)
+
+
+def build_setpoint_payload(values):
+    """Setpoint payloads carry a leading byte before the count."""
+    return b'\x00' + len(values).to_bytes(2, 'big') + b''.join(v.to_bytes(2, 'big') for v in values)
+
+
+class SupportedDeviceTest(unittest.TestCase):
+    def test_every_supported_device_loads(self):
+        """Loading must not raise. A model that raises here is silently swallowed by the
+        receive thread, and the user only sees a setup timeout."""
+        for args, expected_name in SUPPORTED_DEVICES:
+            with self.subTest(device=args):
+                self.assertTrue(NilanProxyModelAdapter.provides_model(*args))
+                self.assertEqual(NilanProxyModelAdapter(*args).get_model_name(), expected_name)
+
+    def test_unknown_device_is_rejected(self):
+        self.assertFalse(NilanProxyModelAdapter.provides_model(9999, 0, 0, 0))
+        with self.assertRaises(Exception):
+            NilanProxyModelAdapter(9999, 0, 0, 0)
+
+    def test_adapters_do_not_share_values(self):
+        first = NilanProxyModelAdapter(*CTS400)
+        second = NilanProxyModelAdapter(1040, 0, 79250, 1)
+        first.parse_datapoint_response(100, build_datapoint_payload([1] * len(first._current_datapoint_list[100])))
+        for key in second._current_datapoint_list[100]:
+            self.assertIsNone(second.get_value(key), f"{key.value} leaked from another adapter")
+
+
+class DatapointDecodingTest(unittest.TestCase):
+    def setUp(self):
+        self.adapter = NilanProxyModelAdapter(*CTS400)
+        self.keys = self.adapter._current_datapoint_list[100]
+
+    def payload_with(self, raw_by_key):
+        values = [raw_by_key.get(key, 0) for key in self.keys]
+        return build_datapoint_payload(values)
+
+    def test_request_order_matches_decoding_order(self):
+        """The response is decoded by position, so the request must be built from the
+        same list in the same order or every value lands on the wrong key."""
+        points = self.adapter.getDatapointRequestList(100)
+        self.assertEqual(len(points), len(self.keys))
+        for point, key in zip(points, self.keys):
+            self.assertIs(point, self.adapter._loaded_model.datapoints[key])
+
+    def test_divider_is_applied(self):
+        self.adapter.parse_datapoint_response(100, self.payload_with({NilanProxyDatapointKey.HUMIDITY: 445}))
+        self.assertEqual(self.adapter.get_value(NilanProxyDatapointKey.HUMIDITY), 44.5)
+
+    def test_signed_values_decode_negative(self):
+        self.adapter.parse_datapoint_response(100, self.payload_with({NilanProxyDatapointKey.TEMP_OUTSIDE: 0x10000 - 50}))
+        self.assertEqual(self.adapter.get_value(NilanProxyDatapointKey.TEMP_OUTSIDE), -5.0)
+
+    def test_unsigned_values_do_not_decode_negative(self):
+        self.adapter.parse_datapoint_response(100, self.payload_with({NilanProxyDatapointKey.CO2_LEVEL: 0xFFFF}))
+        self.assertEqual(self.adapter.get_value(NilanProxyDatapointKey.CO2_LEVEL), 0xFFFF)
+
+    def test_average_humidity_decodes_from_its_own_register(self):
+        """humidity and humidity_average are separate registers and must not shadow
+        each other. A zero here means the register is zero, not that decoding failed."""
+        self.assertIn(NilanProxyDatapointKey.HUMIDITY_AVG, self.keys)
+        self.adapter.parse_datapoint_response(100, self.payload_with({
+            NilanProxyDatapointKey.HUMIDITY: 445,
+            NilanProxyDatapointKey.HUMIDITY_AVG: 512,
+        }))
+        self.assertEqual(self.adapter.get_value(NilanProxyDatapointKey.HUMIDITY), 44.5)
+        self.assertEqual(self.adapter.get_value(NilanProxyDatapointKey.HUMIDITY_AVG), 51.2)
+
+    def test_read_modifier_is_applied(self):
+        """filter_ok flips the raw register value."""
+        self.adapter.parse_datapoint_response(100, self.payload_with({NilanProxyDatapointKey.FILTER_OK: 1}))
+        self.assertEqual(self.adapter.get_value(NilanProxyDatapointKey.FILTER_OK), 0)
+        self.adapter.parse_datapoint_response(100, self.payload_with({NilanProxyDatapointKey.FILTER_OK: 0}))
+        self.assertEqual(self.adapter.get_value(NilanProxyDatapointKey.FILTER_OK), 1)
+
+    def test_short_response_leaves_later_points_untouched(self):
+        """A truncated response must not shift the remaining values onto wrong keys."""
+        self.adapter.parse_datapoint_response(100, build_datapoint_payload([7]))
+        self.assertIsNone(self.adapter.get_value(self.keys[1]))
+
+    def test_unknown_sequence_is_ignored(self):
+        self.adapter.parse_datapoint_response(999, self.payload_with({NilanProxyDatapointKey.HUMIDITY: 445}))
+        self.assertIsNone(self.adapter.get_value(NilanProxyDatapointKey.HUMIDITY))
+
+
+class UpdateHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.adapter = NilanProxyModelAdapter(*CTS400)
+        self.keys = self.adapter._current_datapoint_list[100]
+        self.seen = []
+        self.adapter.register_update_handler(NilanProxyDatapointKey.HUMIDITY, lambda old, new: self.seen.append((old, new)))
+
+    def payload_with(self, raw_by_key):
+        return build_datapoint_payload([raw_by_key.get(key, 0) for key in self.keys])
+
+    def test_handler_fires_on_change(self):
+        self.adapter.parse_datapoint_response(100, self.payload_with({NilanProxyDatapointKey.HUMIDITY: 445}))
+        self.assertEqual(self.seen, [(-1, 44.5)])
+
+    def test_handler_does_not_fire_when_value_is_unchanged(self):
+        payload = self.payload_with({NilanProxyDatapointKey.HUMIDITY: 445})
+        self.adapter.parse_datapoint_response(100, payload)
+        self.adapter.parse_datapoint_response(100, payload)
+        self.assertEqual(len(self.seen), 1)
+
+    def test_deregistered_handler_stops_firing(self):
+        handler = self.adapter._update_handlers[NilanProxyDatapointKey.HUMIDITY][0]
+        self.adapter.deregister_update_handler(NilanProxyDatapointKey.HUMIDITY, handler)
+        self.adapter.parse_datapoint_response(100, self.payload_with({NilanProxyDatapointKey.HUMIDITY: 445}))
+        self.assertEqual(self.seen, [])
+
+
+class SetpointTest(unittest.TestCase):
+    def setUp(self):
+        self.adapter = NilanProxyModelAdapter(*CTS400)
+        self.keys = self.adapter._current_setpoint_list[200]
+
+    def test_setpoint_response_decodes(self):
+        key = NilanProxySetpointKey.TEMP_TARGET
+        self.assertIn(key, self.keys)
+        point = self.adapter.get_setpoint(key)
+        divider = self.adapter.get_point_divider(point)
+        values = [0] * len(self.keys)
+        values[self.keys.index(key)] = 21 * divider
+        self.adapter.parse_setpoint_response(200, build_setpoint_payload(values))
+        self.assertEqual(self.adapter.get_value(key), 21)
+
+    def test_min_and_max_are_converted_like_values(self):
+        for key in self.keys:
+            with self.subTest(setpoint=key.value):
+                self.assertLessEqual(self.adapter.get_min_value(key), self.adapter.get_max_value(key))
+
+    def test_write_conversion_round_trips(self):
+        for key in self.keys:
+            point = self.adapter.get_setpoint(key)
+            if self.adapter.get_point_read_modifier(point) is not None:
+                continue  # modifiers are lossy by design, eg hours to days
+            with self.subTest(setpoint=key.value):
+                raw = self.adapter.get_point_min(point)
+                value = self.adapter.parse_from_modbus_value(point, raw)
+                self.assertEqual(self.adapter.parseToModbusValue(point, value), raw)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Three related commits. The first fixes the crash reported in HairingX/nilan_connect#1, the second repairs the test suite so it could catch it, and the third makes the connection state honest.

## 1. Device address handling (`8e67d71`)

An unset ip in a config entry reached `set_device` as the literal string `"None"` with port `0`. That was stored as a valid address, so `wait_for_discovery` returned immediately without ever broadcasting, and `socket.sendto` then tried to resolve `"None"` as a hostname:

```
sendto -> socket.gaierror: [Errno -2] Name or service not known
```

The reporter saw errno `-5` instead of `-2`, which is the same failure through a resolver that appends a search domain.

- `set_device` validates the address and falls back to discovery when it is not a usable IPv4 address and port. Hostnames are rejected on purpose, the address is only a cache that discovery refreshes.
- `connect_to_device` returns `False` when no address is known instead of letting `socket.gaierror` escape into the integration setup.
- `wait_for_discovery` resends the broadcast while waiting, so one dropped udp packet no longer fails the whole discovery.
- Discovery answers always update the cached address now, and the reconnect path asks discovery again. A device that gets a new dhcp lease while unreachable is picked up instead of being retried forever on a dead address.

This keeps discovered devices working without a static ip, per the [discovery-update-info](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/discovery-update-info) rule.

## 2. Test suite (`923c25f`)

The tests were written against an older model API and every model test errored in `setUp`, so nothing was verified. Rewriting them against the current API surfaced four real bugs:

- **CTS602 could not load at all.** `_quirks` was built at the end of `__init__` but looked up at the start, so every CTS602 raised `AttributeError`. The receive thread swallows that, leaving the user with a setup timeout and no explanation. Confirmed against the published wheels, not just this checkout:
  ```
  running nilan_proxy version: 1.0.2
  CTS400  (1140/72270/1) -> CTS 400
  CTS602Light (sm=2)     -> CTS 602 light
  CTS602  (sm=12)        -> AttributeError: 'NilanProxyCTS602' object has no attribute '_quirks'
  ```
  1.0.0 and 1.0.1 fail the same way. CTS602 has never worked in this library.
- **All models shared the same dicts.** `datapoints`, `setpoints` and `_configs` were class attributes no model rebound, so a CTS400 ended up with 64 configs, 8 of them for points it does not have, collected from other models loaded in the same process.
- **`DEFAULT_CONFIGS` was mutated in place.** `set_default_configs` handed out the shared entries and the Optima models wrote their unit into them:
  ```
  CTS400 alone        : days
  Optima270           : months
  CTS400 after Optima : months
  ```
- **Optima 301 and 312 configured a setpoint they do not have.** It only worked because another model had already put the key in the shared dict, and raised `KeyError` once that was fixed. The lines were dead code and are removed.

The adapter had the same problem for `_values` and `_update_handlers`, so two devices in one process shared readings.

Coverage now includes point definitions, config completeness, model isolation, device to model mapping, and datapoint and setpoint decoding including dividers, signed values and read modifiers. Run against the previous source the suite produces **556 failures and 33 errors**; against this branch all **222 tests pass**.

Added `.github/workflows/test.yml` so they run on push and pull request across the python versions Home Assistant ships. There was no test gate before, which is how the CTS602 breakage reached PyPI.

## 3. Unavailability (`47ad465`)

`is_connected` was set once after the handshake and never cleared, so a silent device still looked connected and consumers kept presenting the last reading as current.

Availability is tracked separately rather than by clearing `is_connected`. That flag gates the polling and reconnect logic in the receive thread, so clearing it on a dropped connection would stop the reconnect attempts and the device would never come back. A test pins that down.

`is_available` goes false after `SECONDS_UNTILUNAVAILABLE` (60s, three reconnect attempts and six missed polls) and recovers on the next answer. Listeners register through `register_connection_state_handler` and are notified only on a change. A listener that raises is logged and skipped so it cannot kill the receive thread.

## Release ordering

`nilan_connect` pins `nilan_proxy~=1.0.3`, which does not exist on PyPI yet. This needs to be merged and released first, then the integration.

## Testing

```
Ran 222 tests in 15.079s
OK
```

Line endings are unchanged, this repo is LF throughout.
